### PR TITLE
Added closing server method

### DIFF
--- a/lib/proxy-tamper.js
+++ b/lib/proxy-tamper.js
@@ -2,6 +2,8 @@ var http = require('http');
 
 var ProxyTamper = function (options) {
   var _patterns = [];
+  var sockets = {};
+  var nextSocketId = 0;
 
   var _server = http.createServer(function (req, resp) {
     var proxy = null;
@@ -122,9 +124,23 @@ var ProxyTamper = function (options) {
     });
   }).listen(options.port);
 
+  _server.on('connection', function (socket) {
+    var socketId = nextSocketId++;
+    sockets[socketId] = socket;
+    socket.on('close', function () {
+      delete sockets[socketId];
+    });
+  });
+  
   return {
     tamper: function (pattern, obj) {
       _patterns.unshift({ pattern: pattern, tamper: obj });
+    },
+    end: function () {
+      for (var socketId in sockets) {
+        sockets[socketId].destroy();
+      }
+      _server.close();
     }
   };
 }


### PR DESCRIPTION
Im using your plugin to mock some services in my BDD tests, for some tests I dont need it so I have to close the server in order to retrieve the real response.

To close it:
```
var proxy = require('./lib/proxy-tamper').start({port: 8080});
//your code
proxy.end()
```